### PR TITLE
fix(pins): jitter co-located vendor pins and mark Dershway as removed

### DIFF
--- a/Data/VendorDatabase.lua
+++ b/Data/VendorDatabase.lua
@@ -1072,8 +1072,11 @@ VendorDatabase.Vendors = {
             {246703, cost = {gold = 3000000, items = {{id = 169610, amount = 3}}}},
         },
     },
+	-- Dershway the Triggered: removed from game in Patch 11.2.7 (Dec 2025).
+	-- Replaced by original vendor Quackenbush [68363] at the same Brawlpub spot.
 	[151941] = {
         name = "Dershway the Triggered",
+        unreleased = true,
         mapID = 84,
         x = 0.700, y = 0.370,
         zone = "Stormwind",


### PR DESCRIPTION
Co-located vendors at the same (mapID, x, y) stack pins on top of each
other, making the bottom vendor unreachable. Add a lightweight JitterPin
helper that nudges the 2nd+ pin by ±0.003 in x — enough to separate
pins visually while staying imperceptible for waypoints. Applied to both
world map and minimap pin placement paths.

Affected overlaps (2 active groups):
- Frostwall Trading Post: Ribchewer [86776] + Krixel Pinchwhistle [86779]
- Saltheril's Haven: Caeris Fairdawn [240838] + Ranger Allorn [242724]

Also flag Dershway the Triggered [151941] as unreleased — NPC was removed
from the game in Patch 11.2.7 (Dec 2025), replaced by Quackenbush [68363].
This eliminates the Brawlpub overlap without needing jitter.

Lunarfall overlap (Maybell [88126] + Peter [88220]) left as-is pending
in-game coordinate verification (existing TODO in data).

Co-Authored-By: Royaleint and Claude Code

https://claude.ai/code/session_019xDMroAkz98eNbD3KgujbL