### PR TITLE
Fix oversized world map pins

### DIFF
--- a/Core/constants.lua
+++ b/Core/constants.lua
@@ -490,7 +490,7 @@ Constants.Defaults = {
             showOppositeFaction = true,  -- Show vendors for opposite faction with faction emblem
             pinColorPreset = "default",              -- Color preset key or "custom"
             pinColorCustom = { r = 1, g = 1, b = 1 }, -- RGB for custom pin color
-            pinIconSize = 20,                          -- Base icon size for world map pins (12-32)
+            pinIconSize = 10,                          -- Base icon size for world map pins (8-18)
             minimapIconSize = 12,                      -- Minimap pin size (8-24)
             showPinCounts = true,                      -- Show collected/total counts on vendor pins
             worldMapZoneBadges = false,                -- Show zone-level badges on world map instead of continent totals

--- a/Core/core.lua
+++ b/Core/core.lua
@@ -47,6 +47,13 @@ function HousingAddon:OnInitialize()
     -- Clean up removed setting from SavedVariables (requirement scraping removed)
     self.db.global.enableRequirementScraping = nil
 
+    -- One-time migration: pin size default was too large for native pin system.
+    -- Old default was 20, runtime clamped to 18. Reset users at either value to 10.
+    local vt = self.db.profile.vendorTracer
+    if vt and vt.pinIconSize and vt.pinIconSize >= 18 then
+        vt.pinIconSize = 10
+    end
+
     -- Set up profile callbacks
     self.db.RegisterCallback(self, "OnProfileChanged", "OnProfileChanged")
     self.db.RegisterCallback(self, "OnProfileCopied", "OnProfileChanged")

--- a/UI/MapSidePanel.lua
+++ b/UI/MapSidePanel.lua
@@ -2079,18 +2079,15 @@ local PIN_COLOR_ORDER = {
 }
 
 local PIN_SIZE_LABELS = {
-    [2] = "2 px",
-    [4] = "4 px",
-    [6] = "6 px",
     [8] = "8 px",
-    [10] = "10 px",
+    [10] = "Default (10)",
     [12] = "12 px",
-    [14] = "Default (14)",
+    [14] = "14 px",
     [16] = "16 px",
     [18] = "18 px",
 }
 
-local PIN_SIZE_ORDER = { 2, 4, 6, 8, 10, 12, 14, 16, 18 }
+local PIN_SIZE_ORDER = { 8, 10, 12, 14, 16, 18 }
 
 local function ShowContextMenu(owner)
     MenuUtil.CreateContextMenu(owner, function(_, rootDescription)

--- a/UI/Options.lua
+++ b/UI/Options.lua
@@ -565,7 +565,7 @@ local function GetOptionsTable()
                         name = L["World map pin size"],
                         desc = L["desc_world_pin_size"],
                         order = 6,
-                        min = 2,
+                        min = 8,
                         max = 18,
                         step = 2,
                         width = "double",

--- a/UI/PinFrameFactory.lua
+++ b/UI/PinFrameFactory.lua
@@ -55,9 +55,9 @@ end
 
 function PinFrameFactory:GetPinIconSize()
     local db = HA.Addon and HA.Addon.db
-    if not db then return 14 end
-    local size = db.profile.vendorTracer.pinIconSize or 14
-    return math.max(2, math.min(18, size))
+    if not db then return 10 end
+    local size = db.profile.vendorTracer.pinIconSize or 10
+    return math.max(8, math.min(18, size))
 end
 
 function PinFrameFactory:GetMinimapIconSize()


### PR DESCRIPTION
## Summary

- Reduced default pin size from 20 to 10 for the native pin rendering system
- Narrowed slider range from 2-18 to 8-18
- Added one-time migration to reset existing users at the old default (18+) to 10
- Updated right-click pin size menu to match new range

Closes #28

## Test plan

- [ ] Open world map — pins should be reasonably sized at default 10
- [ ] Pin size slider in settings shows range 8-18
- [ ] Right-click pin size menu shows 8-18 with "Default (10)" label
- [ ] Existing users with saved pinIconSize of 18-20 get migrated to 10