### PR TITLE
STU-034 post-merge cleanup — HS-061/HS-062 reconciliation + cutover SHA

### DIFF
--- a/Home_Completed.md
+++ b/Home_Completed.md
@@ -140,6 +140,16 @@ completion date. Active and queued work lives in `Home_Tracker.md`.
   - Ren/Gronthul data asymmetry at Razorwind Shores (Gronthul's 58-item list omits 244778) — possible Horde-mirror quirk. File separately if mirror parity is desired.
 - **Spec:** `Homestead/Home_Dev/plans/active/HS-059-sethraliss-pillow-ownership.md`
 
+### HS-061 Route Migration 1→2 decorID write through `_save`
+- **Type:** Maintenance (Hardening)
+- **Priority:** Low
+- **Status:** Complete (2026-04-15)
+- **Completed:** 2026-04-15 — Commit `fbba0bb`, merge `b610766` to Homestead main. Argus Gate 1 PASS on all five lenses. Rawb Gate 2 PASS (smoke test: `/reload` clean, ownership counts unchanged).
+- **Discovered:** Argus Gate 1 review of HS-059 (originally proposed as HS-059-FU-4).
+- **Acceptance criteria:** In `Data/CatalogStore.lua`, the Migration 1→2 path that writes `record.decorID = data.recordID` directly is refactored to route through `_save` (or an equivalent helper that also updates the `itemIDToDecor` reverse index). Reverse-index invariant is enforced structurally, not by `Initialize` ordering.
+- **Session context:** Currently safe by ordering — `BuildDecorIndex` runs after migrations in `Initialize`, so the rebuild captures the migration's writes. If a future code path runs `BuildDecorIndex` before migrations, the reverse index drifts silently.
+- **Notes:** A trap, not a current bug. Zero player impact today. Argus Gate 1 strengthened the rejection rationale for alt (b) — `self:Save` would fire `CATALOG_ITEM_UPDATED` mid-migration before subscribers expect a coherent store.
+
 ### HS-057 Update Wago.io landing page
 - **Reclassified:** Originally logged as HS-051 (duplicate ID). Renumbered to HS-057 in STU-023.
 - **Type:** Community

--- a/Home_Completed.md
+++ b/Home_Completed.md
@@ -160,5 +160,5 @@ completion date. Active and queued work lives in `Home_Tracker.md`.
 - **Notes:** Current page may be using default/minimal description. Review competitor addon pages for what works.
 
 ---
-Pre-split history: Royaleint/BawrLabs@<CUTOVER-SHA>:BACKLOG.md
-Archaeology: `git log -S "<ITEM-ID>" -- BACKLOG.md` at that SHA
+Pre-split history: Royaleint/BawrLabs@2951ea8:BACKLOG.md
+Archaeology: `git log -S "<ITEM-ID>" -- BACKLOG.md` at commit 2951ea8^ (the commit before BACKLOG.md was deleted)

--- a/Home_Tracker.md
+++ b/Home_Tracker.md
@@ -20,28 +20,6 @@ Active and queued work for the Homestead addon. Completed items live in
 - **Session context:** `ShiftMapRight()` calls `WorldMapFrame:SetPoint()` directly, tainting the protected frame's layout. `UnifyTopBorder()` reads `GetTop()`/`GetBottom()` from protected children (NavBar, BorderFrame, ScrollContainer) and modifies `TopEdge:SetPoint()`. `ApplyContentInset()` reads `GetBottom()` from protected children. The `HomesteadWorldMapProvider` ticker reads `canvas:GetWidth()` every 0.1s. All in `UI/MapSidePanel.lua` and `UI/HomesteadWorldMapProvider.lua`. Taint cascades to `GameTooltip` widget system (`GameTooltip_AddWidgetSet`, `GameTooltip_InsertFrame`), quest frame, and tooltip layout. Latest 2026-03-28 user-reported secret-number stacks matched the now-fixed UISpecialFrames taint, so this item remains unconfirmed until reproduced with `09e93ad` in place.
 - **Notes:** Separate from the UISpecialFrames taint, which was fully removed in `09e93ad` after the original partial fix in `8f906ff`. Pre-existing since panel border integration was built. Requires reworking how the panel docks to the map — cannot directly call SetPoint/GetTop/GetBottom on WorldMapFrame or its protected children. Needs PLAN_TEMPLATE.md.
 
-### HS-062 ADDON_ACTION_FORBIDDEN on world map toggle in PvP (PerformEmote taint)
-- **Type:** Bug
-- **Priority:** Medium
-- **Status:** Backlog
-- **GitHub:** [#33](https://github.com/Royaleint/Homestead/issues/33)
-- **Reported:** 2026-04-13, via BugGrabber capture during a PvP match (Homestead v2.3.1).
-- **Symptom:** `ADDON_ACTION_FORBIDDEN: AddOn 'Homestead' tried to call the protected function 'PerformEmote()'` fires when the user opens the world map in PvP. Map still opens; error is noise, not a functional block.
-- **Stack:** Entirely Blizzard code — `TOGGLEWORLDMAP` → `ToggleWorldMap` → `HandleUserActionToggleSelf` → `SetDisplayState` → `ShowUIPanel` → `SetAttribute` → `Show` → `Blizzard_WorldMap.lua:352` (anon handler) → `PerformEmote`. Homestead does not appear in the stack. This is a **taint cascade**, not a direct call — Blizzard attributes blame to the most-recently-tainted addon in the execution context.
-- **Suspect code paths (`UI/MapSidePanel.lua`):**
-  - `hooksecurefunc(WorldMapFrame, "HandleUserActionMaximizeSelf", ...)` at 4074 and `"MinimizeSelf"` at 4093 — siblings to the `HandleUserActionToggleSelf` in the stack.
-  - `hooksecurefunc(WorldMapFrame, "SetMapID", ...)` at 4019.
-  - `hooksecurefunc(WorldMapFrame, "RefreshOverlayFrames", ...)` at 2208.
-  - `WorldMapFrame:SetPoint(...)` in `ShiftMapRight` (~3120) for side-panel nudge.
-  - `SetParent(panelFrame)` on Blizzard-owned subframes (`portraitContainer`, `navBar`, `tutorial`) at 3207–3278 for integrated mode.
-- **Acceptance criteria:** BugGrabber no longer captures `ADDON_ACTION_FORBIDDEN / PerformEmote` attributed to Homestead when opening the world map, in PvP and in all other contexts verified during the investigation. Side-panel integration still works on default UI.
-- **Investigation plan (Gate 0, before any fix):**
-  1. Reproduce without PvP — dungeon, raid, arena lobby, BG waiting room, open world. PvP may just be first-noticed, not causal.
-  2. Test with `integrateMapBorder = false` (standalone mode) — if error disappears, the reparenting of Blizzard subframes is the taint source. Standalone mode doesn't reparent.
-  3. If standalone mode still errors, the `hooksecurefunc` closures on `HandleUserActionMaximizeSelf`/`MinimizeSelf` become prime suspects — disable those hooks and retest.
-  4. Investigate replacing `SetParent` on Blizzard subframes with cross-parent anchoring (positioning-only) — would remove the most taint-heavy operation while preserving the visual integration.
-- **Notes:** Not player-blocking but eroding trust (error spam during PvP). Do not start a fix until the investigation pinpoints the taint source — this is exactly the class of bug that gets "fixed" by a plausible change that doesn't actually address the root cause.
-
 ### HS-054 World-level continent summary should scope to current map view
 - **Type:** Bug
 - **Priority:** Medium
@@ -316,15 +294,6 @@ Active and queued work for the Homestead addon. Completed items live in
 - **Session context:** None yet. Pick up after HS-059 ships and the `/hsdev hs059record` probe is removed.
 - **Notes:** Likely produces both player-visible fixes (if scanner is broken) and internal hygiene (docs). HS-061 (migration write hardening) is a separate low-priority item, not folded here.
 
-### HS-061 Route Migration 1→2 decorID write through `_save`
-- **Type:** Maintenance (Hardening)
-- **Priority:** Low
-- **Status:** Backlog
-- **Discovered:** Argus Gate 1 review of HS-059 (originally proposed as HS-059-FU-4).
-- **Acceptance criteria:** In `Data/CatalogStore.lua`, the Migration 1→2 path that writes `record.decorID = data.recordID` directly is refactored to route through `_save` (or an equivalent helper that also updates the `itemIDToDecor` reverse index). Reverse-index invariant is enforced structurally, not by `Initialize` ordering.
-- **Session context:** Currently safe by ordering — `BuildDecorIndex` runs after migrations in `Initialize`, so the rebuild captures the migration's writes. If a future code path runs `BuildDecorIndex` before migrations, the reverse index drifts silently.
-- **Notes:** A trap, not a current bug. Zero player impact today. Fold into the next refactor that touches migrations or the catalog store.
-
 ### Stale
 
 ### HS-006 Apply pipeline data corrections
@@ -397,6 +366,29 @@ Active and queued work for the Homestead addon. Completed items live in
   - Consider new catalogspike subcommand to inspect dye variant data on entry frames
   - Add Decor Duels test item to `ApiTest.lua TEST_ITEMS` after PTR scan
 - **Notes:** Research at `BawrLabs/projects/` (no dedicated doc yet). Blizzard Watch, Wowhead, MMO-Champion, and official PTR notes all reviewed.
+
+### HS-062 ADDON_ACTION_FORBIDDEN on world map toggle in PvP (PerformEmote taint)
+- **Type:** Bug
+- **Priority:** Medium
+- **Status:** In Progress (investigation prepped)
+- **GitHub:** [#33](https://github.com/Royaleint/Homestead/issues/33)
+- **Reported:** 2026-04-13, via BugGrabber capture during a PvP match (Homestead v2.3.1).
+- **Symptom:** `ADDON_ACTION_FORBIDDEN: AddOn 'Homestead' tried to call the protected function 'PerformEmote()'` fires when the user opens the world map in PvP. Map still opens; error is noise, not a functional block.
+- **Stack:** Entirely Blizzard code — `TOGGLEWORLDMAP` → `ToggleWorldMap` → `HandleUserActionToggleSelf` → `SetDisplayState` → `ShowUIPanel` → `SetAttribute` → `Show` → `Blizzard_WorldMap.lua:352` (anon handler) → `PerformEmote`. Homestead does not appear in the stack. This is a **taint cascade**, not a direct call — Blizzard attributes blame to the most-recently-tainted addon in the execution context.
+- **Suspect code paths (`UI/MapSidePanel.lua`):**
+  - `hooksecurefunc(WorldMapFrame, "HandleUserActionMaximizeSelf", ...)` at 4074 and `"MinimizeSelf"` at 4093 — siblings to the `HandleUserActionToggleSelf` in the stack.
+  - `hooksecurefunc(WorldMapFrame, "SetMapID", ...)` at 4019.
+  - `hooksecurefunc(WorldMapFrame, "RefreshOverlayFrames", ...)` at 2208.
+  - `WorldMapFrame:SetPoint(...)` in `ShiftMapRight` (~3120) for side-panel nudge.
+  - `SetParent(panelFrame)` on Blizzard-owned subframes (`portraitContainer`, `navBar`, `tutorial`) at 3207–3278 for integrated mode.
+- **Acceptance criteria:** BugGrabber no longer captures `ADDON_ACTION_FORBIDDEN / PerformEmote` attributed to Homestead when opening the world map, in PvP and in all other contexts verified during the investigation. Side-panel integration still works on default UI.
+- **Investigation plan (Gate 0, before any fix):**
+  1. Reproduce without PvP — dungeon, raid, arena lobby, BG waiting room, open world. PvP may just be first-noticed, not causal.
+  2. Test with `integrateMapBorder = false` (standalone mode) — if error disappears, the reparenting of Blizzard subframes is the taint source. Standalone mode doesn't reparent.
+  3. If standalone mode still errors, the `hooksecurefunc` closures on `HandleUserActionMaximizeSelf`/`MinimizeSelf` become prime suspects — disable those hooks and retest.
+  4. Investigate replacing `SetParent` on Blizzard subframes with cross-parent anchoring (positioning-only) — would remove the most taint-heavy operation while preserving the visual integration.
+- **Session context (2026-04-15):** Investigation brief completed with full Gate 0 code read of MapSidePanel.lua. 10 taint vectors inventoried (T1–T10, ranked high→low). Grep confirmed all WorldMapFrame mutations scoped to MapSidePanel.lua only. Gate 3 has 1 non-blocking open question (PerformEmote identity at Blizzard_WorldMap.lua:352). Q1 (other files) and Q2 (integrateMapBorder profile key: `HA.Addon.db.profile.vendorTracer.integrateMapBorder`, toggle labeled "Integrate with map frame border") resolved. Investigation brief at `Home_Dev/plans/active/HS-062-performemote-taint-investigation.md`. NOT approved. Next action: Rawb runs Tests 1 and 2 in-game, reports BugGrabber results. Test 3 (code-edit diagnostic) follows via Prodigy/Douglock.
+- **Notes:** Not player-blocking but eroding trust (error spam during PvP). Do not start a fix until the investigation pinpoints the taint source — this is exactly the class of bug that gets "fixed" by a plausible change that doesn't actually address the root cause.
 
 ## Awaiting Gate 2
 


### PR DESCRIPTION
## Summary

Post-merge follow-up to PR #34 (STU-034 PR 1).

Two commits:

1. **HS-061/HS-062 status reconciliation.** PR 1 extracted from \`BawrLabs/BACKLOG.md\` as it stood on \`origin/main\`, which missed an unpushed local-main commit (\`8a5e880\`) that updated HS-061 to Complete (2026-04-15) and HS-062 to In Progress. This commit ports those status changes:
   - HS-061 moved from Home_Tracker.md (Maintenance) → Home_Completed.md (\`Completed: 2026-04-15\`) with completion notes
   - HS-062 moved from Home_Tracker.md Bugs (Backlog) → In Progress, with 2026-04-15 Session context describing the investigation brief

2. **Cutover SHA fill-in.** Replaces the literal \`<CUTOVER-SHA>\` placeholder in Home_Completed.md footer with BawrLabs PR 3 merge commit \`2951ea8\` (2026-04-20).

After this merges, \`git -C C:/Projects/BawrLabs reset --hard origin/main\` can safely discard the obsolete local \`8a5e880\` commit (its content is now preserved in main via this PR).

## Test plan

- [ ] HS-061 appears in Home_Completed.md chronologically between HS-059 (2026-04-12) and HS-057 (2026-04-19)
- [ ] HS-061 no longer appears in Home_Tracker.md
- [ ] HS-062 appears in Home_Tracker.md \`## In Progress\` section with \`Status: In Progress (investigation prepped)\`
- [ ] HS-062 no longer appears in Home_Tracker.md \`### Bugs\` sub-section
- [ ] Home_Completed.md footer reads \`Royaleint/BawrLabs@2951ea8:BACKLOG.md\` (no more \`<CUTOVER-SHA>\` placeholder)